### PR TITLE
Uses consistent property declarations throughout the project

### DIFF
--- a/ISHPermissionKit/ISHPermissionsViewController.h
+++ b/ISHPermissionKit/ISHPermissionsViewController.h
@@ -59,7 +59,7 @@ typedef void (^ISHPermissionsViewControllerCompletionBlock)(void);
  *  once the dismissal of the view controller has been completed.
  *  Otherwise it is called immediately after informing the delegate.
  */
-@property (strong) ISHPermissionsViewControllerCompletionBlock completionBlock;
+@property (copy) ISHPermissionsViewControllerCompletionBlock completionBlock;
 
 @end
 

--- a/ISHPermissionKit/Requests/ISHPermissionRequest.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequest.m
@@ -10,7 +10,7 @@
 @import CoreLocation;
 
 @interface ISHPermissionRequest ()
-@property (readwrite) ISHPermissionCategory permissionCategory;
+@property (nonatomic, readwrite) ISHPermissionCategory permissionCategory;
 @end
 
 @implementation ISHPermissionRequest

--- a/ISHPermissionKit/Requests/ISHPermissionRequestAccount.h
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestAccount.h
@@ -11,7 +11,7 @@
 @interface ISHPermissionRequestAccount : ISHPermissionRequest
 
 /// A unique identifier for the account type. Well known system account type identifiers are listed in <Accounts/ACAccountType.h>
-@property (readonly) NSString *accountTypeIdentifier;
+@property (nonatomic, readonly) NSString *accountTypeIdentifier;
 
 /**
  *  An optional dictionary that will be used when requesting access to the account of the given type.

--- a/ISHPermissionKit/Requests/ISHPermissionRequestNotificationsLocal.h
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestNotificationsLocal.h
@@ -11,6 +11,6 @@
 
 @interface ISHPermissionRequestNotificationsLocal : ISHPermissionRequest
 #ifdef __IPHONE_8_0
-@property UIUserNotificationSettings *noticationSettings;
+@property (nonatomic) UIUserNotificationSettings *noticationSettings;
 #endif
 @end

--- a/ISHPermissionKit/Requests/ISHPermissionRequestNotificationsLocal.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestNotificationsLocal.m
@@ -10,7 +10,7 @@
 #import "ISHPermissionRequest+Private.h"
 
 @interface ISHPermissionRequestNotificationsLocal ()
-@property (strong) ISHPermissionRequestCompletionBlock completionBlock;
+@property (copy) ISHPermissionRequestCompletionBlock completionBlock;
 @end
 
 @implementation ISHPermissionRequestNotificationsLocal

--- a/PermissionsTestApp/AppDelegate.h
+++ b/PermissionsTestApp/AppDelegate.h
@@ -10,8 +10,7 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-@property (strong, nonatomic) UIWindow *window;
-
+@property (nonatomic) UIWindow *window;
 
 @end
 


### PR DESCRIPTION
All properties are nonatomic, unless there is a reason for them to be atomic (currently not the case in any file)

Blocks are declared using 'copy', as recommended by Apple: https://developer.apple.com/library/ios/documentation/cocoa/conceptual/ProgrammingWithObjectiveC/WorkingwithBlocks/WorkingwithBlocks.html#//apple_ref/doc/uid/TP40011210-CH8-SW12

Do not specify default attributes, such as, 'strong' for object references
