### PR TITLE
Fix bugs with wrong state on completion in camera and mic

### DIFF
--- a/ISHPermissionKit/Requests/ISHPermissionRequestMicrophone.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestMicrophone.m
@@ -46,8 +46,9 @@
     
     [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            [self setInternalPermissionState:granted ? ISHPermissionStateAuthorized : ISHPermissionStateDenied];
-            completion(self, granted, nil);
+            ISHPermissionState state = granted ? ISHPermissionStateAuthorized : ISHPermissionStateDenied;
+            [self setInternalPermissionState:state];
+            completion(self, state, nil);
         });
     }];
 }

--- a/ISHPermissionKit/Requests/ISHPermissionRequestPhotoCamera.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestPhotoCamera.m
@@ -45,7 +45,8 @@
     
     [AVCaptureDevice requestAccessForMediaType:AVMediaTypeVideo completionHandler:^(BOOL granted) {
         dispatch_async(dispatch_get_main_queue(), ^{
-            completion(self, granted, nil);
+            ISHPermissionState state = granted ? ISHPermissionStateAuthorized : ISHPermissionStateDenied;
+            completion(self, state, nil);
         });
     }];
 }


### PR DESCRIPTION
Instead of a `ISHPermissionState` there was a boolean passed to the completion block, which resulted in wrong state even if the permission was given by the user.