### PR TITLE
Remove auto-generated library version accessors

### DIFF
--- a/ISHPermissionKit/ISHPermissionKit.h
+++ b/ISHPermissionKit/ISHPermissionKit.h
@@ -8,12 +8,6 @@
 
 #import <UIKit/UIKit.h>
 
-//! Project version number for ISHPermissionKit.
-FOUNDATION_EXPORT double ISHPermissionKitVersionNumber;
-
-//! Project version string for ISHPermissionKit.
-FOUNDATION_EXPORT const unsigned char ISHPermissionKitVersionString[];
-
 // Public module headers
 #import <ISHPermissionKit/ISHPermissionsViewController.h>
 #import <ISHPermissionKit/ISHPermissionRequestViewController.h>


### PR DESCRIPTION
They do not work with static libraries nor with CocoaPods. To make the umbrella header universally useful without hidden bug potential, it's better to remove them entirely.