### PR TITLE
Refactor bulk state queries to fix issues for configurable requests

### DIFF
--- a/ISHPermissionKit/ISHPermissionsViewController.h
+++ b/ISHPermissionKit/ISHPermissionsViewController.h
@@ -98,6 +98,15 @@ typedef void (^ISHPermissionsViewControllerErrorBlock)(ISHPermissionCategory, NS
  */
 @property (copy, nullable) ISHPermissionsViewControllerErrorBlock errorBlock;
 
+/**
+ *  Returns the permission categories that will be requested by the ISHPermissionsViewController when presented.
+ *
+ *  @return An array of boxed ISHPermissionCategory values for which the
+ *          user can be prompted among the array of
+ *          categories given in the initializer of ISHPermissionsViewController.
+ *          The relative sorting of the categories is maintained.
+ */
+- (NSArray<NSNumber *> *)permissionCategories;
 @end
 
 #pragma mark - Protocols

--- a/ISHPermissionKit/Requests/ISHPermissionRequest+All.h
+++ b/ISHPermissionKit/Requests/ISHPermissionRequest+All.h
@@ -29,29 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (ISHPermissionRequest *)requestForCategory:(ISHPermissionCategory)category;
 
-/**
- *  Check the permission state for an array of permissions and return those that have been granted.
- *
- *  @param categories Array of boxed ISHPermissionCategory to check for permission state.
- *
- *  @return An array of boxed ISHPermissionCategory values for which the
- *          user has granted permissions among the array of
- *          categories given as an argument.
- *          The relative sorting of the categories is maintained.
- */
-+ (NSArray<NSNumber *> *)grantedPermissionsForCategories:(NSArray<NSNumber *> *)categories;
 
-/**
- *  Check the permission state for an array of permissions and return those that can still be requested.
- *
- *  @param categories Array of boxed ISHPermissionCategory to check for permission state.
- *
- *  @return An array of boxed ISHPermissionCategory values for which the
- *          user can be prompted among the array of
- *          categories given as an argument.
- *          The relative sorting of the categories is maintained.
- */
-+ (NSArray<NSNumber *> *)requestablePermissionsForCategories:(NSArray<NSNumber *> *)categories;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ISHPermissionKit/Requests/ISHPermissionRequest+All.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequest+All.m
@@ -85,30 +85,4 @@
     return request;
 }
 
-+ (NSArray<NSNumber *> *)grantedPermissionsForCategories:(NSArray<NSNumber *> *)categories {
-    return [self permissionsForCategories:categories passingTest:^BOOL (ISHPermissionState state) {
-        return state == ISHPermissionStateAuthorized;
-    }];
-}
-
-+ (NSArray<NSNumber *> *)requestablePermissionsForCategories:(NSArray<NSNumber *> *)categories {
-    return [self permissionsForCategories:categories passingTest:^BOOL (ISHPermissionState state) {
-        return ISHPermissionStateAllowsUserPrompt(state);
-    }];
-}
-
-+ (NSArray<NSNumber *> *)permissionsForCategories:(NSArray<NSNumber *> *)categories passingTest:(BOOL (^_Nonnull)(ISHPermissionState))testBlock {
-    NSMutableArray *grantedPermissions = [NSMutableArray array];
-
-    for (NSNumber *boxedCategory in categories) {
-        ISHPermissionRequest *request = [ISHPermissionRequest requestForCategory:boxedCategory.unsignedIntegerValue];
-
-        if (testBlock([request permissionState])) {
-            [grantedPermissions addObject:boxedCategory];
-        }
-    }
-
-    return [grantedPermissions copy];
-}
-
 @end

--- a/ISHPermissionKit/Requests/ISHPermissionRequest.h
+++ b/ISHPermissionKit/Requests/ISHPermissionRequest.h
@@ -120,6 +120,8 @@ typedef void (^ISHPermissionRequestCompletionBlock)(ISHPermissionRequest *reques
  *
  *  @return The current permission state.
  *  @note Calling this method does not trigger any user interaction.
+ *  @warning If the request needs to be configured, the configuration must be 
+ *           applied before relying on the value returned from this method.
  */
 - (ISHPermissionState)permissionState;
 

--- a/PermissionsTestApp/AppDelegate.h
+++ b/PermissionsTestApp/AppDelegate.h
@@ -7,10 +7,12 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <ISHPermissionKit/ISHPermissionKit.h>
 
-@interface AppDelegate : UIResponder<UIApplicationDelegate>
+@interface AppDelegate : UIResponder<UIApplicationDelegate, ISHPermissionsViewControllerDataSource>
 
 @property (nonatomic, nullable) UIWindow *window;
 
++ (AppDelegate *)appDelegate;
 + (nonnull NSArray<NSNumber *> *)requiredPermissions;
 @end

--- a/PermissionsTestApp/AppDelegate.m
+++ b/PermissionsTestApp/AppDelegate.m
@@ -9,15 +9,17 @@
 #import "AppDelegate.h"
 #import "SamplePermissionViewController.h"
 #import "GrantedPermissionsViewController.h"
-
-#import <ISHPermissionKit/ISHPermissionKit.h>
 @import Accounts;
 
-@interface AppDelegate ()<ISHPermissionsViewControllerDataSource>
+@interface AppDelegate ()
 @property (nonatomic, weak) GrantedPermissionsViewController *rootViewController;
 @end
 
 @implementation AppDelegate
+
++ (AppDelegate *)appDelegate {
+    return (AppDelegate *)[[UIApplication sharedApplication] delegate];
+}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [self setupWindow];
@@ -50,7 +52,7 @@
     ISHPermissionsViewController *permissionsVC = [ISHPermissionsViewController permissionsViewControllerWithCategories:permissions dataSource:self];
     __weak GrantedPermissionsViewController *rootVC = self.rootViewController;
     [permissionsVC setCompletionBlock:^{
-        [rootVC reloadPermissions];
+        [rootVC reloadPermissionsUsingDataSource:self];
     }];
     
     __weak ISHPermissionsViewController *weakPermissionsVC = permissionsVC;

--- a/PermissionsTestApp/GrantedPermissionsViewController.h
+++ b/PermissionsTestApp/GrantedPermissionsViewController.h
@@ -7,7 +7,8 @@
 //
 
 #import <UIKit/UIKit.h>
+#import <ISHPermissionKit/ISHPermissionKit.h>
 
 @interface GrantedPermissionsViewController : UITableViewController
-- (void)reloadPermissions;
+- (void)reloadPermissionsUsingDataSource:(id<ISHPermissionsViewControllerDataSource>)datasource;
 @end


### PR DESCRIPTION
The issue with the previous implementation was that the requests would not be properly configured leading to false states. The current setup with the PermissionsViewController at the center does not really allow for a query about all granted permissions. If there is sufficient interest in getting a set of all granted permissions (as opposed to the lack of no request-able permissions), we would need to refactor the dataSource away from the permissions view controller into a separate protocol.

This PR removes the method `grantedPermissionsForCategories`. The previous method `requestablePermissionRequestsForCategories` is now simply the permissions viewcontroller's `permissionCategories` .