### PR TITLE
Add Coverage configuration based on Debug config

### DIFF
--- a/ISHPermissionKit.xcodeproj/project.pbxproj
+++ b/ISHPermissionKit.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		1BC93E4F1D7063D20033B6E8 /* ISHPermissionRequestMusicLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BC93E491D7063D20033B6E8 /* ISHPermissionRequestMusicLibrary.m */; };
 		1BC93E531D7063F10033B6E8 /* ISHPermissionRequestMusicLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC93E521D7063F10033B6E8 /* ISHPermissionRequestMusicLibrary.h */; };
 		1BC93E541D7063F10033B6E8 /* ISHPermissionRequestMusicLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = 1BC93E521D7063F10033B6E8 /* ISHPermissionRequestMusicLibrary.h */; };
+		1BDB4D911DAD4F1D0046E4E5 /* ISHPermissionKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCC1BFA5195B174200362559 /* ISHPermissionKit.framework */; };
 		DC1A80A3195B21DC0069235F /* ISHPermissionsViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1A80A1195B21DC0069235F /* ISHPermissionsViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DC1A80A4195B21DC0069235F /* ISHPermissionsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1A80A2195B21DC0069235F /* ISHPermissionsViewController.m */; };
 		DC1A80A9195B22A10069235F /* ISHPermissionCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1A80A8195B22A10069235F /* ISHPermissionCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -104,6 +105,16 @@
 		DCD56C7F1962BB8600508F4A /* ISHPermissionRequestHealth.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD56C7C1962BB8600508F4A /* ISHPermissionRequestHealth.m */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		1BDB4D8F1DAD4F1A0046E4E5 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DCC1BF9C195B174200362559 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DCC1BFA4195B174200362559;
+			remoteInfo = ISHPermissionKit;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXCopyFilesBuildPhase section */
 		DCAEF7C8195C60070074EB5B /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -136,6 +147,7 @@
 		1BBCCA7E1BFF367D00606D3D /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		1BC93E491D7063D20033B6E8 /* ISHPermissionRequestMusicLibrary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISHPermissionRequestMusicLibrary.m; sourceTree = "<group>"; };
 		1BC93E521D7063F10033B6E8 /* ISHPermissionRequestMusicLibrary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ISHPermissionRequestMusicLibrary.h; path = ISHPermissionKit/Private/ISHPermissionRequestMusicLibrary.h; sourceTree = SOURCE_ROOT; };
+		1BDB4D881DAD4DB00046E4E5 /* ISHPermissionKitFlagsCoverage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = ISHPermissionKitFlagsCoverage.xcconfig; sourceTree = "<group>"; };
 		DC1A80A1195B21DC0069235F /* ISHPermissionsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISHPermissionsViewController.h; sourceTree = "<group>"; };
 		DC1A80A2195B21DC0069235F /* ISHPermissionsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ISHPermissionsViewController.m; sourceTree = "<group>"; };
 		DC1A80A8195B22A10069235F /* ISHPermissionCategory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ISHPermissionCategory.h; sourceTree = "<group>"; };
@@ -200,6 +212,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1BDB4D911DAD4F1D0046E4E5 /* ISHPermissionKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -324,6 +337,7 @@
 			children = (
 				DCC1BFA9195B174200362559 /* Info.plist */,
 				1B7221721DA3DD7B00B9266F /* ISHPermissionKitFlags.xcconfig */,
+				1BDB4D881DAD4DB00046E4E5 /* ISHPermissionKitFlagsCoverage.xcconfig */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -463,6 +477,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				1BDB4D901DAD4F1A0046E4E5 /* PBXTargetDependency */,
 			);
 			name = ISHPermissionKitTests;
 			productName = ISHPermissionKitTests;
@@ -593,7 +608,119 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		1BDB4D901DAD4F1A0046E4E5 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DCC1BFA4195B174200362559 /* ISHPermissionKit */;
+			targetProxy = 1BDB4D8F1DAD4F1A0046E4E5 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		1BDB4D841DAD4D850046E4E5 /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1BDB4D881DAD4DB00046E4E5 /* ISHPermissionKitFlagsCoverage.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 2;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ISH_BUNDLE_VERSION = 0;
+				ISH_BUNDLE_VERSION_MAJOR = 1;
+				ISH_BUNDLE_VERSION_MINOR = 2;
+				ISH_BUNDLE_VERSION_SHORT = "${ISH_BUNDLE_VERSION_MAJOR}.${ISH_BUNDLE_VERSION_MINOR}.${ISH_BUNDLE_VERSION}";
+				METAL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Coverage;
+		};
+		1BDB4D851DAD4D850046E4E5 /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				CURRENT_PROJECT_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				DYLIB_CURRENT_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				INFOPLIST_FILE = ISHPermissionKit/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "de.iosphere.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Coverage;
+		};
+		1BDB4D861DAD4D850046E4E5 /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CURRENT_PROJECT_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				DYLIB_COMPATIBILITY_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				DYLIB_CURRENT_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				FRAMEWORK_VERSION = "${ISH_BUNDLE_VERSION_SHORT}";
+				METAL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = "include/$(PROJECT_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Coverage;
+		};
+		1BDB4D871DAD4D850046E4E5 /* Coverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				INFOPLIST_FILE = ISHPermissionKitTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				METAL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_BUNDLE_IDENTIFIER = "de.iosphere.${PRODUCT_NAME:rfc1034identifier}";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Coverage;
+		};
 		DCAEF7DC195C60070074EB5B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -802,6 +929,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DCAEF7DC195C60070074EB5B /* Debug */,
+				1BDB4D861DAD4D850046E4E5 /* Coverage */,
 				DCAEF7DD195C60070074EB5B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -811,6 +939,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DCC1BFB9195B174200362559 /* Debug */,
+				1BDB4D841DAD4D850046E4E5 /* Coverage */,
 				DCC1BFBA195B174200362559 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -820,6 +949,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DCC1BFBC195B174200362559 /* Debug */,
+				1BDB4D851DAD4D850046E4E5 /* Coverage */,
 				DCC1BFBD195B174200362559 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -829,6 +959,7 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				DCC1BFBF195B174200362559 /* Debug */,
+				1BDB4D871DAD4D850046E4E5 /* Coverage */,
 				DCC1BFC0195B174200362559 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/ISHPermissionKit.xcodeproj/xcshareddata/xcschemes/ISHPermissionKit.xcscheme
+++ b/ISHPermissionKit.xcodeproj/xcshareddata/xcschemes/ISHPermissionKit.xcscheme
@@ -23,11 +23,21 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Coverage"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DCC1BFAF195B174200362559"
+               BuildableName = "ISHPermissionKitTests.xctest"
+               BlueprintName = "ISHPermissionKitTests"
+               ReferencedContainer = "container:ISHPermissionKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/ISHPermissionKit.xcodeproj/xcshareddata/xcschemes/ISHPermissionKitLib.xcscheme
+++ b/ISHPermissionKit.xcodeproj/xcshareddata/xcschemes/ISHPermissionKitLib.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Coverage"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/ISHPermissionKit/ISHPermissionKitFlagsCoverage.xcconfig
+++ b/ISHPermissionKit/ISHPermissionKitFlagsCoverage.xcconfig
@@ -1,0 +1,26 @@
+//
+//  ISHPermissionKitFlags.xcconfig
+//  ISHPermissionKit
+//
+//  Created by Hagi on 04/10/16.
+//  Copyright © 2016 iosphere GmbH. All rights reserved.
+//
+
+// This file enables all feature flags for the Coverage configuration. Should not be used in production.
+
+ISH_PERMISSION_FLAG_MOTION          = ISHPermissionRequestMotionEnabled
+ISH_PERMISSION_FLAG_HEALTH          = ISHPermissionRequestHealthKitEnabled
+ISH_PERMISSION_FLAG_LOCATION        = ISHPermissionRequestLocationEnabled
+ISH_PERMISSION_FLAG_MIC             = ISHPermissionRequestMicrophoneEnabled
+ISH_PERMISSION_FLAG_PHOTOS          = ISHPermissionRequestPhotoLibraryEnabled
+ISH_PERMISSION_FLAG_CAMERA          = ISHPermissionRequestCameraEnabled
+ISH_PERMISSION_FLAG_NOTIFICATIONS   = ISHPermissionRequestNotificationsEnabled
+ISH_PERMISSION_FLAG_SOCIAL          = ISHPermissionRequestSocialAccountsEnabled
+ISH_PERMISSION_FLAG_CONTACTS        = ISHPermissionRequestContactsEnabled
+ISH_PERMISSION_FLAG_CALENDAR        = ISHPermissionRequestCalendarEnabled
+ISH_PERMISSION_FLAG_REMINDERS       = ISHPermissionRequestRemindersEnabled
+ISH_PERMISSION_FLAG_SIRI            = ISHPermissionRequestSiriEnabled
+ISH_PERMISSION_FLAG_SPEECH          = ISHPermissionRequestSpeechEnabled
+ISH_PERMISSION_FLAG_MUSIC           = ISHPermissionRequestMusicLibraryEnabled
+
+GCC_PREPROCESSOR_DEFINITIONS[config=Coverage] = $(inherited) $(ISH_PERMISSION_FLAG_MOTION) $(ISH_PERMISSION_FLAG_HEALTH) $(ISH_PERMISSION_FLAG_LOCATION) $(ISH_PERMISSION_FLAG_MIC) $(ISH_PERMISSION_FLAG_PHOTOS) $(ISH_PERMISSION_FLAG_CAMERA) $(ISH_PERMISSION_FLAG_NOTIFICATIONS) $(ISH_PERMISSION_FLAG_SOCIAL) $(ISH_PERMISSION_FLAG_CONTACTS) $(ISH_PERMISSION_FLAG_CALENDAR) $(ISH_PERMISSION_FLAG_REMINDERS) $(ISH_PERMISSION_FLAG_SIRI) $(ISH_PERMISSION_FLAG_SPEECH) $(ISH_PERMISSION_FLAG_MUSIC)


### PR DESCRIPTION
Coverage is set as default config for tests. Tests can be run from the dynamic framework target.