### PR TITLE
Add subspecs for all permission categories

### DIFF
--- a/ISHPermissionKit.podspec
+++ b/ISHPermissionKit.podspec
@@ -27,11 +27,116 @@ Pod::Spec.new do |s|
     core.requires_arc         = true
   end
 
+  s.subspec 'Motion' do |motion|
+    motion.dependency 'ISHPermissionKit/Core'
+    motion.weak_framework       = 'CoreMotion'
+    feature_flags               = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestMotionEnabled' }
+    motion.pod_target_xcconfig  = feature_flags
+    motion.user_target_xcconfig = feature_flags
+  end
+
   s.subspec 'Health' do |health|
    health.dependency 'ISHPermissionKit/Core'
-
    health.weak_framework       = 'HealthKit'
-   health.pod_target_xcconfig  = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestHealthKitEnabled' }
+   feature_flags               = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestHealthKitEnabled' }
+   health.pod_target_xcconfig  = feature_flags
+   health.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Location' do |location|
+    location.dependency 'ISHPermissionKit/Core'
+    location.weak_framework       = 'CoreLocation'
+    feature_flags                 = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestLocationEnabled' }
+    location.pod_target_xcconfig  = feature_flags
+    location.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Microphone' do |mic|
+    mic.dependency 'ISHPermissionKit/Core'
+    mic.weak_framework       = 'AVFoundation'
+    feature_flags            = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestMicrophoneEnabled' }
+    mic.pod_target_xcconfig  = feature_flags
+    mic.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'PhotoLibrary' do |photo|
+    photo.dependency 'ISHPermissionKit/Core'
+    photo.weak_framework       = 'Photos', 'AssetsLibrary'
+    feature_flags              = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestPhotoLibraryEnabled' }
+    photo.pod_target_xcconfig  = feature_flags
+    photo.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Camera' do |cam|
+    cam.dependency 'ISHPermissionKit/Core'
+    cam.weak_framework       = 'AVFoundation'
+    feature_flags            = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestCameraEnabled' }
+    cam.pod_target_xcconfig  = feature_flags
+    cam.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Notifications' do |note|
+    note.dependency 'ISHPermissionKit/Core'
+    note.weak_framework       = 'UIKit', 'UserNotifications'
+    feature_flags             = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestNotificationsEnabled' }
+    note.pod_target_xcconfig  = feature_flags
+    note.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'SocialAccounts' do |social|
+    social.dependency 'ISHPermissionKit/Core'
+    social.weak_framework       = 'Accounts'
+    feature_flags               = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestSocialAccountsEnabled' }
+    social.pod_target_xcconfig  = feature_flags
+    social.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Contacts' do |contacts|
+    contacts.dependency 'ISHPermissionKit/Core'
+    contacts.weak_framework       = 'Contacts', 'AddressBook'
+    feature_flags                 = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestContactsEnabled' }
+    contacts.pod_target_xcconfig  = feature_flags
+    contacts.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Calendar' do |cal|
+    cal.dependency 'ISHPermissionKit/Core'
+    cal.weak_framework       = 'EventKit'
+    feature_flags            = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestCalendarEnabled' }
+    cal.pod_target_xcconfig  = feature_flags
+    cal.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Reminders' do |rem|
+    rem.dependency 'ISHPermissionKit/Core'
+    rem.weak_framework       = 'EventKit'
+    feature_flags            = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestRemindersEnabled' }
+    rem.pod_target_xcconfig  = feature_flags
+    rem.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Siri' do |siri|
+    siri.dependency 'ISHPermissionKit/Core'
+    siri.weak_framework       = 'Intents'
+    feature_flags             = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestSiriEnabled' }
+    siri.pod_target_xcconfig  = feature_flags
+    siri.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'Speech' do |speech|
+    speech.dependency 'ISHPermissionKit/Core'
+    speech.weak_framework       = 'Speech'
+    feature_flags               = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestSpeechEnabled' }
+    speech.pod_target_xcconfig  = feature_flags
+    speech.user_target_xcconfig = feature_flags
+  end
+
+  s.subspec 'MusicLibrary' do |music|
+    music.dependency 'ISHPermissionKit/Core'
+    music.weak_framework       = 'MediaPlayer'
+    feature_flags              = { 'GCC_PREPROCESSOR_DEFINITIONS' => 'ISHPermissionRequestMusicLibraryEnabled' }
+    music.pod_target_xcconfig  = feature_flags
+    music.user_target_xcconfig = feature_flags
   end
 
 end

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ least iOS 8 is required. If you use Swift, you must use dynamic frameworks.
 
 ### Providing a Build Configuration
 
-When building the static or dynamic library, *ISHPermissionKit* will look for an
-`.xcconfig` file in the same directory as *ISHPermissionKit*'s root directory 
-(not *within* the root directory). This file allows you to set preprocessor flags
-that will be used when compiling the framework.
+When building the static or dynamic library, *ISHPermissionKit* will look for a
+file named `ISHPermissionKitAppConfiguration.xcconfig` in the same directory as
+*ISHPermissionKit*'s root directory (not *within* the root directory). This file
+allows you to set preprocessor flags that will be used when compiling the framework.
 
 We strongly recommend to start with a copy of the template config provided in this
 repository, [`ISHPermissionKitAppConfiguration.xcconfig`](/ISHPermissionKitAppConfiguration.xcconfig).
@@ -132,7 +132,7 @@ You will have to use the same configuration file to build your app, else the
 category-specific symbols will not be available. In your project settings, you
 can select a configuration file for each target:
 
-![Weak-linking a framework in Xcode](assets/config_file.png)
+![Setting a configuration file](assets/config_file.png)
 
 If you already use a configuration file, you can pick one and include the other
 in it. Ensure to always use `$(inherit)` when setting preprocessor macros.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ your app, and set to "Optional". Feel free to duplicate rdar://28008958
 This is currently required for the *Speech* framework, and only if you
 enable the speech permission category.
 
-### CocoaPods
+### Cocoa Pods
 
 You can use CocoaPods to install *ISHPermissionKit* as a static or dynamic library.
 Each permission category requires a separate (sub)pod. The following sample Podfile

--- a/README.md
+++ b/README.md
@@ -137,6 +137,24 @@ can select a configuration file for each target:
 If you already use a configuration file, you can pick one and include the other
 in it. Ensure to always use `$(inherit)` when setting preprocessor macros.
 
+### Required Frameworks
+
+*ISHPermissionKit* uses system frameworks to accomplish its tasks. Most of
+them will be linked automatically unless you have disabled "Enable Modules"
+(`CLANG_ENABLE_MODULES`) and "Link Frameworks Automatically" 
+(`CLANG_MODULES_AUTOLINK`) in your app target's build settings.
+
+Unfortunately, some framework are not weakly linked automatically which
+will cause your app to crash at launch on older systems that don't support
+the respective framework. These frameworks must be explicitly linked in
+your app, and set to "Optional". Feel free to duplicate rdar://28008958
+(https://openradar.appspot.com/search?query=28008958).
+
+![Weak-linking a framework in Xcode](assets/weak_linking.png)
+
+This is currently required for the *Speech* framework, and only if you
+enable the speech permission category.
+
 ### CocoaPods
 
 You can use CocoaPods to install *ISHPermissionKit* as a static or dynamic library.
@@ -160,33 +178,16 @@ target 'MyApp' do
   pod 'ISHPermissionKit/Reminders'
   pod 'ISHPermissionKit/Siri'
   pod 'ISHPermissionKit/Speech'
-  pod 'ISHPermissionKit/Music'
+  pod 'ISHPermissionKit/MusicLibrary'
 end
 ```
 
 [Providing a build configuration](#providing-a-build-configuration) manually is not
-required when you use CocoaPods.
+required when you use CocoaPods, and you can also ignore the
+[Required Frameworks](#required-frameworks) section.
 
 See the [official website](https://cocoapods.org/#get_started) to get started with
 CocoaPods.
-
-### Required Frameworks
-
-*ISHPermissionKit* uses system frameworks to accomplish its tasks. Most of
-them will be linked automatically unless you have disabled "Enable Modules"
-(`CLANG_ENABLE_MODULES`) and "Link Frameworks Automatically" 
-(`CLANG_MODULES_AUTOLINK`) in your app target's build settings.
-
-Unfortunately, some framework are not weakly linked automatically which
-will cause your app to crash at launch on older systems that don't support
-the respective framework. These frameworks must be explicitly linked in
-your app, and set to "Optional". Feel free to duplicate rdar://28008958
-(https://openradar.appspot.com/search?query=28008958).
-
-![Weak-linking a framework in Xcode](assets/weak_linking.png)
-
-This is currently required for the *Speech* framework, and only if you
-enable the speech permission category.
 
 ## ISHPermissionsViewController
 


### PR DESCRIPTION
The respective flags must be enabled for:

* the pod target so the library builds correctly
* the user target so the autocompletion works correctly

I've double-checked that the preprocessor macros are appended and do not overwrite existing flags.

I've also verified that weak-linking works as expected so the workaround for frameworks that do not weak-link by default is not necessary when using CocoaPods. I've changed the README accordingly.