### PR TITLE
Fix assertion in iOS 11 when adding subviews to effect views

### DIFF
--- a/ISHPermissionKit/ISHPermissionsViewController.m
+++ b/ISHPermissionKit/ISHPermissionsViewController.m
@@ -271,7 +271,13 @@
                                     }
                                 }];
     } else {
-        [[self view] addSubview:toViewController.view];
+        if ([self.view isKindOfClass:[UIVisualEffectView class]]) {
+            UIVisualEffectView *effectView = (UIVisualEffectView *)self.view;
+            [effectView.contentView addSubview:toViewController.view];
+        } else {
+            [self.view addSubview:toViewController.view];
+        }
+
         [toViewController.view setFrame:self.view.bounds];
         [self completedTransitionFromViewController:nil toViewController:toViewController];
     }


### PR DESCRIPTION
Note: This controller instantiates a visual effects view by default, so this is a common case.

Error message:

>*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: '<UIView: 0x7fe1ded71c60; frame = (0 0; 375 667); autoresize = W+H; layer = <CALayer: 0x61000062e580>> has been added as a subview to <UIVisualEffectView: 0x7fe1db3ebfe0; frame = (-187.5 -333.5; 375 667); autoresize = W+H; layer = <CALayer: 0x61800043eaa0>>. Do not add subviews directly to the visual effect view itself, instead add them to the -contentView.'