### PR TITLE
Add debug warning when missing 'NSLocationAlwaysAndWhenInUseUsageDescription

### DIFF
--- a/ISHPermissionKit/Requests/ISHPermissionRequestLocation.m
+++ b/ISHPermissionKit/Requests/ISHPermissionRequestLocation.m
@@ -177,7 +177,7 @@
 #if DEBUG
 - (NSArray<NSString *> *)staticUsageDescriptionKeyss {
     if (self.permissionCategory == ISHPermissionCategoryLocationAlways) {
-        return @[@"NSLocationAlwaysUsageDescription"];
+        return @[@"NSLocationAlwaysUsageDescription", @"NSLocationAlwaysAndWhenInUseUsageDescription"];
     } else {
         return @[@"NSLocationWhenInUseUsageDescription"];
     }


### PR DESCRIPTION
Since iOS 11, 'NSLocationAlwaysAndWhenInUseUsageDescription' and 'NSLocationAlwaysUsageDescription' are required when requesting always permission